### PR TITLE
fix for subtitle encoding

### DIFF
--- a/SubtitleAPI.js
+++ b/SubtitleAPI.js
@@ -122,7 +122,7 @@ function decode(content, encoding) {
         logger.Debug('Decoding with: ' + encoding);
         var iconv = require('iconv-lite');
         if(iconv.encodingExists(encoding))
-            var buffer = iconv.decode(content, 'win1251');
+            var buffer = iconv.decode(content, encoding);
         else
             buffer = content;
     } else {


### PR DESCRIPTION
Noticed my subtitles stopped working after move to iconv-lite.
It was just a really small fix.